### PR TITLE
fix: `invalid key` error on small displays (#2)

### DIFF
--- a/.github/workflows/commit-messages.yaml
+++ b/.github/workflows/commit-messages.yaml
@@ -1,0 +1,18 @@
+name: 'Commit message check'
+on: [ push, pull_request ]
+jobs:
+  # Taken from https://github.com/marketplace/actions/gs-commit-message-checker
+  check-commit-message:
+    name: Commit message nicely formatted
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gsactions/commit-message-checker@v1
+        with:
+          # pattern: '^((:bug: fix|:lipstick: refactor|:green_book: docs|:sparkles: feat|:broom: chore|:wrench: tooling|:rewind: revert|:zap: speed|:tada: release) | (fix|refactor|doc|docs|feat|chore|tooling|revert|)(\([^ ]+\))?): [^ ]+'
+          # pattern: '^((:bug: )?build|(:bug: )?chore|(:bug: )?ci|(:bug: )?docs|(:bug: )?feat|(:bug: )?fix|(:bug: )?perf|(:bug: )?refactor|(:bug: )?revert|(:bug: )?style|(:bug: )?test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
+          pattern: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\.\-\p{Extended_Pictographic}]+\))?(!)?: ([\w \p{Extended_Pictographic}])+([\s\S]*)'
+          error: 'Messages should be formatted as "<emoji> <type>: <description>"'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,18 @@
+name: Luacheck
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  workflow_dispatch:
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Luacheck
+        uses: lunarmodules/luacheck@v1.1.0

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,23 @@
+ignore = {
+  "631",  -- max_line_length
+  --"212/_.*",  -- unused argument, for vars with "_" prefix
+  "212", -- Unused argument, In the case of callback function, _arg_name is easier to understand than _, so this option is set to off.
+  "121", -- setting read-only global variable 'vim'
+  "122", -- setting read-only field of global variable 'vim'
+}
+
+-- Global objects defined by the C code
+read_globals = {
+  "vim",
+}
+
+globals = {
+  "vim.g",
+  "vim.b",
+  "vim.w",
+  "vim.o",
+  "vim.bo",
+  "vim.wo",
+  "vim.go",
+  "vim.env"
+}

--- a/lua/veil.lua
+++ b/lua/veil.lua
@@ -53,6 +53,7 @@ function veil.display(replace)
 	veil.state.open = true
 	local timer = vim.loop.new_timer()
 	veil.redraw(true)
+
 	timer:start(
 		200,
 		200,
@@ -120,10 +121,9 @@ function veil.redraw(init)
 		vim.api.nvim_buf_set_lines(veil.buf, 0, -1, true, utils.empty(win_height - veil_height))
 	end
 
-	-- local entry = { 0, 1, on_interact }
 	local current_height = 0
 	if veil_height < win_height then
-		current_height = math.ceil((win_height - (veil_height * 2)) / 2)
+		current_height = math.floor((win_height - (veil_height * 2)) / 2)
 	end
 	for id, section in ipairs(rendered) do
 		if not section.virt then
@@ -136,7 +136,7 @@ function veil.redraw(init)
 			end
 			vim.api.nvim_buf_set_extmark(veil.buf, veil.ns, current_height, 0, {
 				id = id,
-				virt_text_pos = "overlay",
+				virt_text_pos = "eol",
 				virt_lines = virt,
 			})
 		end


### PR DESCRIPTION
- use `eol` instead of `overlay` for virtual text
- use `floor` instead of `ceil` for start line calculation